### PR TITLE
[SolrFlute] Prevent query-overriding to the same field

### DIFF
--- a/dbflute_maihamadb/freegen/solr/SolrBsFilterQueryBean.vm
+++ b/dbflute_maihamadb/freegen/solr/SolrBsFilterQueryBean.vm
@@ -17,8 +17,8 @@ ${manager.allClassCopyright}package ${request.package}.cbean.cfq.bs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
 import org.dbflute.util.DfStringUtil;
 
@@ -58,6 +58,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=${column.name}:* )
      */
     public void set${column.capCamelName}_Exists() {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         this.${column.uncapCamelName}Query = SolrQueryBuilder.queryBuilderForExists("${column.name}");
     }
 
@@ -65,6 +66,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT ${column.name}:* )
      */
     public void set${column.capCamelName}_NotExists() {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         this.${column.uncapCamelName}Query = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("${column.name}"), false);
     }
 
@@ -77,6 +79,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_Equal(${column.type.replace("[]", "")} query) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
 #if(${column.type.replace("[]", "")} == "String")
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
 #else
@@ -87,6 +90,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_NotEqual(${column.type.replace("[]", "")} query) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
 #if(${column.type.replace("[]", "")} == "String")
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
 #else
@@ -102,6 +106,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -109,6 +114,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -116,6 +122,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("${column.name}", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -135,6 +142,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -142,6 +150,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("${column.name}", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -149,6 +158,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("${column.name}", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -161,6 +171,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -168,6 +179,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<${column.type}> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -187,6 +199,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -199,6 +212,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchIntegerList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -206,6 +220,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<${column.type}> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchIntegerList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -225,6 +240,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -246,6 +262,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -258,6 +275,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchBigDecimalList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -265,6 +283,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<${column.type}> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchBigDecimalList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -284,6 +303,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -292,6 +312,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
 
 #elseif($column.nativeType == "text_ja")
     public void set${column.capCamelName}_FreewordSearch(${column.type} queryStrs, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForFreewordSearch("${column.name}", queryStrs, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -299,6 +320,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_FreewordSearch(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery  = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -307,6 +329,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
 
 #elseif($column.nativeType == "text_cjk")
     public void set${column.capCamelName}_FreewordSearch(${column.type} queryStrs, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForFreewordSearch("${column.name}", queryStrs, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -314,6 +337,7 @@ public class SolrBs${tableMap.schema}CFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void set${column.capCamelName}_FreewordSearch(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery  = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;

--- a/dbflute_maihamadb/freegen/solr/SolrBsQueryBean.vm
+++ b/dbflute_maihamadb/freegen/solr/SolrBsQueryBean.vm
@@ -17,8 +17,8 @@ ${manager.allClassCopyright}package ${request.package}.cbean.cq.bs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.solr.client.solrj.SolrQuery.ORDER;
 import org.apache.solr.client.solrj.SolrQuery.SortClause;
@@ -71,6 +71,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=${column.name}:* )
      */
     public void set${column.capCamelName}_Exists() {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         this.${column.uncapCamelName}Query = SolrQueryBuilder.queryBuilderForExists("${column.name}");
     }
 
@@ -78,6 +79,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT ${column.name}:* )
      */
     public void set${column.capCamelName}_NotExists() {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         this.${column.uncapCamelName}Query = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("${column.name}"), false);
     }
 
@@ -90,6 +92,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_Equal(${column.type.replace("[]", "")} query) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
 #if(${column.type.replace("[]", "")} == "String")
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
 #else
@@ -100,6 +103,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_NotEqual(${column.type.replace("[]", "")} query) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
 #if(${column.type.replace("[]", "")} == "String")
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
 #else
@@ -115,6 +119,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -122,6 +127,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -129,6 +135,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("${column.name}", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -148,6 +155,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -155,6 +163,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("${column.name}", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -162,6 +171,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("${column.name}", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -184,6 +194,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -191,6 +202,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<${column.type}> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -210,6 +222,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -232,6 +245,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchIntegerList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -239,6 +253,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<${column.type}> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchIntegerList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -258,6 +273,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -299,6 +315,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -321,6 +338,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_InScope(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchBigDecimalList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -328,6 +346,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_NotInScope(Collection<${column.type}> queryList) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchBigDecimalList("${column.name}", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -347,6 +366,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_RangeSearch(${column.type} from, ${column.type} to) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("${column.name}", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -365,6 +385,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
 
 #elseif($column.nativeType == "text_ja")
     public void set${column.capCamelName}_FreewordSearch(${column.type} queryStrs, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForFreewordSearch("${column.name}", queryStrs, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -372,6 +393,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_FreewordSearch(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery  = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -380,6 +402,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
 
 #elseif($column.nativeType == "text_cjk")
     public void set${column.capCamelName}_FreewordSearch(${column.type} queryStrs, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery = SolrQueryBuilder.queryBuilderForFreewordSearch("${column.name}", queryStrs, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;
@@ -387,6 +410,7 @@ public class SolrBs${tableMap.schema}CQ extends AbstractSolrQueryBean {
     }
 
     public void set${column.capCamelName}_FreewordSearch(Collection<${column.type}> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("${column.name}", this.${column.uncapCamelName}Query);
         String convertedQuery  = SolrQueryBuilder.queryBuilderForSearchWordList("${column.name}", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.${column.uncapCamelName}Query = convertedQuery;

--- a/dbflute_maihamadb/freegen/solr/allcommon/solr/cbean/SolrQueryBuilder.vm
+++ b/dbflute_maihamadb/freegen/solr/allcommon/solr/cbean/SolrQueryBuilder.vm
@@ -781,9 +781,20 @@ public class SolrQueryBuilder {
         return DATE_TIME_FORMATTER.format(new HandyDate(date).addHour(timeZoneDiff).getLocalDateTime());
     }
 
+    public static void assertNullQuery(String fieldName, String query) {
+        if (fieldName == null) {
+            String msg = "fieldName should not be null: fieldName=null query=" + query;
+            throw new IllegalArgumentException(msg);
+        }
+        if (query != null) {
+            String msg = "Query for this field is already registered: fieldName:query=" + query;
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
     public static void assertNotNullQuery(String fieldName, String query) {
         if (fieldName == null) {
-            String msg = "The value should not be null: fieldName=null query=" + query;
+            String msg = "fieldName should not be null: fieldName=null query=" + query;
             throw new IllegalArgumentException(msg);
         }
         if (query == null) {

--- a/src/main/java/org/dbflute/solr/cbean/SolrQueryBuilder.java
+++ b/src/main/java/org/dbflute/solr/cbean/SolrQueryBuilder.java
@@ -781,9 +781,20 @@ public class SolrQueryBuilder {
         return DATE_TIME_FORMATTER.format(new HandyDate(date).addHour(timeZoneDiff).getLocalDateTime());
     }
 
+    public static void assertNullQuery(String fieldName, String query) {
+        if (fieldName == null) {
+            String msg = "fieldName should not be null: fieldName=null query=" + query;
+            throw new IllegalArgumentException(msg);
+        }
+        if (query != null) {
+            String msg = "Query for this field is already registered: fieldName:query=" + query;
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
     public static void assertNotNullQuery(String fieldName, String query) {
         if (fieldName == null) {
-            String msg = "The value should not be null: fieldName=null query=" + query;
+            String msg = "fieldName should not be null: fieldName=null query=" + query;
             throw new IllegalArgumentException(msg);
         }
         if (query == null) {

--- a/src/main/java/org/docksidestage/solr/cbean/cfq/bs/SolrBsExampleCFQ.java
+++ b/src/main/java/org/docksidestage/solr/cbean/cfq/bs/SolrBsExampleCFQ.java
@@ -17,8 +17,8 @@ package org.docksidestage.solr.cbean.cfq.bs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
 import org.dbflute.util.DfStringUtil;
 
@@ -85,6 +85,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=latest_purchase_date:* )
      */
     public void setLatestPurchaseDate_Exists() {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         this.latestPurchaseDateQuery = SolrQueryBuilder.queryBuilderForExists("latest_purchase_date");
     }
 
@@ -92,6 +93,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT latest_purchase_date:* )
      */
     public void setLatestPurchaseDate_NotExists() {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         this.latestPurchaseDateQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("latest_purchase_date"), false);
     }
 
@@ -104,12 +106,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setLatestPurchaseDate_Equal(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         if (query != null) {
             this.latestPurchaseDateQuery = SolrQueryBuilder.queryBuilderForEqual("latest_purchase_date", query.toString());
         }
     }
 
     public void setLatestPurchaseDate_NotEqual(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         if (query != null) {
             this.latestPurchaseDateQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("latest_purchase_date", query.toString()), false);
         }
@@ -128,6 +132,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setLatestPurchaseDate_RangeSearch(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("latest_purchase_date", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.latestPurchaseDateQuery = convertedQuery;
@@ -141,6 +146,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=product_category:* )
      */
     public void setProductCategory_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         this.productCategoryQuery = SolrQueryBuilder.queryBuilderForExists("product_category");
     }
 
@@ -148,6 +154,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT product_category:* )
      */
     public void setProductCategory_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         this.productCategoryQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_category"), false);
     }
 
@@ -160,12 +167,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategory_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryQuery = SolrQueryBuilder.queryBuilderForEqual("product_category", query.toString());
         }
     }
 
     public void setProductCategory_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_category", query.toString()), false);
         }
@@ -176,6 +185,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategory_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -183,6 +193,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategory_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -190,6 +201,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategory_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_category", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -209,6 +221,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategory_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_category", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -216,6 +229,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategory_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_category", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -223,6 +237,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategory_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_category", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -236,6 +251,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=product_category_code:* )
      */
     public void setProductCategoryCode_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         this.productCategoryCodeQuery = SolrQueryBuilder.queryBuilderForExists("product_category_code");
     }
 
@@ -243,6 +259,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT product_category_code:* )
      */
     public void setProductCategoryCode_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         this.productCategoryCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_category_code"), false);
     }
 
@@ -255,12 +272,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategoryCode_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryCodeQuery = SolrQueryBuilder.queryBuilderForEqual("product_category_code", query.toString());
         }
     }
 
     public void setProductCategoryCode_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_category_code", query.toString()), false);
         }
@@ -271,6 +290,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategoryCode_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category_code", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -278,6 +298,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategoryCode_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category_code", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -285,6 +306,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategoryCode_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_category_code", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -304,6 +326,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategoryCode_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_category_code", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -311,6 +334,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategoryCode_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_category_code", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -318,6 +342,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductCategoryCode_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_category_code", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -331,6 +356,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=product_handle_code:* )
      */
     public void setProductHandleCode_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         this.productHandleCodeQuery = SolrQueryBuilder.queryBuilderForExists("product_handle_code");
     }
 
@@ -338,6 +364,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT product_handle_code:* )
      */
     public void setProductHandleCode_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         this.productHandleCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_handle_code"), false);
     }
 
@@ -350,12 +377,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductHandleCode_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productHandleCodeQuery = SolrQueryBuilder.queryBuilderForEqual("product_handle_code", query.toString());
         }
     }
 
     public void setProductHandleCode_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productHandleCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_handle_code", query.toString()), false);
         }
@@ -366,6 +395,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductHandleCode_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_handle_code", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -373,6 +403,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductHandleCode_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_handle_code", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -380,6 +411,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductHandleCode_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_handle_code", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -399,6 +431,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductHandleCode_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_handle_code", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -406,6 +439,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductHandleCode_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_handle_code", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -413,6 +447,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductHandleCode_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_handle_code", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -426,6 +461,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=product_name:* )
      */
     public void setProductName_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         this.productNameQuery = SolrQueryBuilder.queryBuilderForExists("product_name");
     }
 
@@ -433,6 +469,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT product_name:* )
      */
     public void setProductName_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         this.productNameQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_name"), false);
     }
 
@@ -445,12 +482,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductName_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productNameQuery = SolrQueryBuilder.queryBuilderForEqual("product_name", query.toString());
         }
     }
 
     public void setProductName_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productNameQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_name", query.toString()), false);
         }
@@ -461,6 +500,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductName_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_name", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -468,6 +508,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductName_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_name", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -475,6 +516,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductName_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_name", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -494,6 +536,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductName_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_name", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -501,6 +544,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductName_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_name", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -508,6 +552,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductName_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_name", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -521,6 +566,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=product_status:* )
      */
     public void setProductStatus_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         this.productStatusQuery = SolrQueryBuilder.queryBuilderForExists("product_status");
     }
 
@@ -528,6 +574,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT product_status:* )
      */
     public void setProductStatus_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         this.productStatusQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_status"), false);
     }
 
@@ -540,12 +587,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatus_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusQuery = SolrQueryBuilder.queryBuilderForEqual("product_status", query.toString());
         }
     }
 
     public void setProductStatus_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_status", query.toString()), false);
         }
@@ -556,6 +605,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatus_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -563,6 +613,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatus_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -570,6 +621,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatus_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_status", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -589,6 +641,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatus_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_status", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -596,6 +649,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatus_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_status", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -603,6 +657,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatus_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_status", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -616,6 +671,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=product_status_code:* )
      */
     public void setProductStatusCode_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         this.productStatusCodeQuery = SolrQueryBuilder.queryBuilderForExists("product_status_code");
     }
 
@@ -623,6 +679,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT product_status_code:* )
      */
     public void setProductStatusCode_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         this.productStatusCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_status_code"), false);
     }
 
@@ -635,12 +692,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatusCode_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusCodeQuery = SolrQueryBuilder.queryBuilderForEqual("product_status_code", query.toString());
         }
     }
 
     public void setProductStatusCode_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_status_code", query.toString()), false);
         }
@@ -651,6 +710,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatusCode_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status_code", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -658,6 +718,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatusCode_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status_code", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -665,6 +726,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatusCode_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_status_code", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -684,6 +746,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatusCode_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_status_code", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -691,6 +754,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatusCode_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_status_code", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -698,6 +762,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setProductStatusCode_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_status_code", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -711,6 +776,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=register_datetime:* )
      */
     public void setRegisterDatetime_Exists() {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         this.registerDatetimeQuery = SolrQueryBuilder.queryBuilderForExists("register_datetime");
     }
 
@@ -718,6 +784,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT register_datetime:* )
      */
     public void setRegisterDatetime_NotExists() {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         this.registerDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("register_datetime"), false);
     }
 
@@ -730,12 +797,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterDatetime_Equal(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         if (query != null) {
             this.registerDatetimeQuery = SolrQueryBuilder.queryBuilderForEqual("register_datetime", query.toString());
         }
     }
 
     public void setRegisterDatetime_NotEqual(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         if (query != null) {
             this.registerDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("register_datetime", query.toString()), false);
         }
@@ -754,6 +823,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterDatetime_RangeSearch(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("register_datetime", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerDatetimeQuery = convertedQuery;
@@ -767,6 +837,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=register_user:* )
      */
     public void setRegisterUser_Exists() {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         this.registerUserQuery = SolrQueryBuilder.queryBuilderForExists("register_user");
     }
 
@@ -774,6 +845,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT register_user:* )
      */
     public void setRegisterUser_NotExists() {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         this.registerUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("register_user"), false);
     }
 
@@ -786,12 +858,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterUser_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.registerUserQuery = SolrQueryBuilder.queryBuilderForEqual("register_user", query.toString());
         }
     }
 
     public void setRegisterUser_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.registerUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("register_user", query.toString()), false);
         }
@@ -802,6 +876,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterUser_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("register_user", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -809,6 +884,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterUser_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("register_user", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -816,6 +892,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterUser_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("register_user", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -835,6 +912,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterUser_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("register_user", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -842,6 +920,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterUser_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("register_user", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -849,6 +928,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegisterUser_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("register_user", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -862,6 +942,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=regular_price:* )
      */
     public void setRegularPrice_Exists() {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         this.regularPriceQuery = SolrQueryBuilder.queryBuilderForExists("regular_price");
     }
 
@@ -869,6 +950,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT regular_price:* )
      */
     public void setRegularPrice_NotExists() {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         this.regularPriceQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("regular_price"), false);
     }
 
@@ -881,12 +963,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegularPrice_Equal(Long query) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         if (query != null) {
             this.regularPriceQuery = SolrQueryBuilder.queryBuilderForEqual("regular_price", query.toString());
         }
     }
 
     public void setRegularPrice_NotEqual(Long query) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         if (query != null) {
             this.regularPriceQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("regular_price", query.toString()), false);
         }
@@ -897,6 +981,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegularPrice_InScope(Collection<Long> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("regular_price", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.regularPriceQuery = convertedQuery;
@@ -904,6 +989,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegularPrice_NotInScope(Collection<Long> queryList) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("regular_price", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.regularPriceQuery = convertedQuery;
@@ -923,6 +1009,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setRegularPrice_RangeSearch(Long from, Long to) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("regular_price", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.regularPriceQuery = convertedQuery;
@@ -936,6 +1023,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=update_datetime:* )
      */
     public void setUpdateDatetime_Exists() {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         this.updateDatetimeQuery = SolrQueryBuilder.queryBuilderForExists("update_datetime");
     }
 
@@ -943,6 +1031,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT update_datetime:* )
      */
     public void setUpdateDatetime_NotExists() {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         this.updateDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("update_datetime"), false);
     }
 
@@ -955,12 +1044,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateDatetime_Equal(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         if (query != null) {
             this.updateDatetimeQuery = SolrQueryBuilder.queryBuilderForEqual("update_datetime", query.toString());
         }
     }
 
     public void setUpdateDatetime_NotEqual(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         if (query != null) {
             this.updateDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("update_datetime", query.toString()), false);
         }
@@ -979,6 +1070,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateDatetime_RangeSearch(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("update_datetime", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateDatetimeQuery = convertedQuery;
@@ -992,6 +1084,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=update_user:* )
      */
     public void setUpdateUser_Exists() {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         this.updateUserQuery = SolrQueryBuilder.queryBuilderForExists("update_user");
     }
 
@@ -999,6 +1092,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
      * ExistsQuery( q=NOT update_user:* )
      */
     public void setUpdateUser_NotExists() {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         this.updateUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("update_user"), false);
     }
 
@@ -1011,12 +1105,14 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateUser_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.updateUserQuery = SolrQueryBuilder.queryBuilderForEqual("update_user", query.toString());
         }
     }
 
     public void setUpdateUser_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.updateUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("update_user", query.toString()), false);
         }
@@ -1027,6 +1123,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateUser_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("update_user", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1034,6 +1131,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateUser_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("update_user", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1041,6 +1139,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateUser_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("update_user", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1060,6 +1159,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateUser_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("update_user", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1067,6 +1167,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateUser_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("update_user", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1074,6 +1175,7 @@ public class SolrBsExampleCFQ extends AbstractSolrFilterQueryBean {
     }
 
     public void setUpdateUser_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("update_user", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;

--- a/src/main/java/org/docksidestage/solr/cbean/cq/bs/SolrBsExampleCQ.java
+++ b/src/main/java/org/docksidestage/solr/cbean/cq/bs/SolrBsExampleCQ.java
@@ -17,8 +17,8 @@ package org.docksidestage.solr.cbean.cq.bs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.solr.client.solrj.SolrQuery.ORDER;
 import org.apache.solr.client.solrj.SolrQuery.SortClause;
@@ -98,6 +98,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=latest_purchase_date:* )
      */
     public void setLatestPurchaseDate_Exists() {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         this.latestPurchaseDateQuery = SolrQueryBuilder.queryBuilderForExists("latest_purchase_date");
     }
 
@@ -105,6 +106,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT latest_purchase_date:* )
      */
     public void setLatestPurchaseDate_NotExists() {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         this.latestPurchaseDateQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("latest_purchase_date"), false);
     }
 
@@ -117,12 +119,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setLatestPurchaseDate_Equal(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         if (query != null) {
             this.latestPurchaseDateQuery = SolrQueryBuilder.queryBuilderForEqual("latest_purchase_date", query.toString());
         }
     }
 
     public void setLatestPurchaseDate_NotEqual(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         if (query != null) {
             this.latestPurchaseDateQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("latest_purchase_date", query.toString()), false);
         }
@@ -141,6 +145,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setLatestPurchaseDate_RangeSearch(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        SolrQueryBuilder.assertNullQuery("latest_purchase_date", this.latestPurchaseDateQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("latest_purchase_date", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.latestPurchaseDateQuery = convertedQuery;
@@ -164,6 +169,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=product_category:* )
      */
     public void setProductCategory_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         this.productCategoryQuery = SolrQueryBuilder.queryBuilderForExists("product_category");
     }
 
@@ -171,6 +177,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT product_category:* )
      */
     public void setProductCategory_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         this.productCategoryQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_category"), false);
     }
 
@@ -183,12 +190,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategory_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryQuery = SolrQueryBuilder.queryBuilderForEqual("product_category", query.toString());
         }
     }
 
     public void setProductCategory_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_category", query.toString()), false);
         }
@@ -199,6 +208,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategory_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -206,6 +216,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategory_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -213,6 +224,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategory_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_category", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -232,6 +244,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategory_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_category", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -239,6 +252,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategory_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_category", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -246,6 +260,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategory_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_category", this.productCategoryQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_category", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryQuery = convertedQuery;
@@ -269,6 +284,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=product_category_code:* )
      */
     public void setProductCategoryCode_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         this.productCategoryCodeQuery = SolrQueryBuilder.queryBuilderForExists("product_category_code");
     }
 
@@ -276,6 +292,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT product_category_code:* )
      */
     public void setProductCategoryCode_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         this.productCategoryCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_category_code"), false);
     }
 
@@ -288,12 +305,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategoryCode_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryCodeQuery = SolrQueryBuilder.queryBuilderForEqual("product_category_code", query.toString());
         }
     }
 
     public void setProductCategoryCode_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productCategoryCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_category_code", query.toString()), false);
         }
@@ -304,6 +323,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategoryCode_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category_code", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -311,6 +331,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategoryCode_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_category_code", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -318,6 +339,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategoryCode_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_category_code", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -337,6 +359,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategoryCode_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_category_code", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -344,6 +367,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategoryCode_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_category_code", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -351,6 +375,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductCategoryCode_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_category_code", this.productCategoryCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_category_code", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productCategoryCodeQuery = convertedQuery;
@@ -374,6 +399,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=product_handle_code:* )
      */
     public void setProductHandleCode_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         this.productHandleCodeQuery = SolrQueryBuilder.queryBuilderForExists("product_handle_code");
     }
 
@@ -381,6 +407,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT product_handle_code:* )
      */
     public void setProductHandleCode_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         this.productHandleCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_handle_code"), false);
     }
 
@@ -393,12 +420,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductHandleCode_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productHandleCodeQuery = SolrQueryBuilder.queryBuilderForEqual("product_handle_code", query.toString());
         }
     }
 
     public void setProductHandleCode_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productHandleCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_handle_code", query.toString()), false);
         }
@@ -409,6 +438,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductHandleCode_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_handle_code", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -416,6 +446,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductHandleCode_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_handle_code", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -423,6 +454,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductHandleCode_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_handle_code", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -442,6 +474,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductHandleCode_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_handle_code", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -449,6 +482,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductHandleCode_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_handle_code", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -456,6 +490,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductHandleCode_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_handle_code", this.productHandleCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_handle_code", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productHandleCodeQuery = convertedQuery;
@@ -479,6 +514,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=product_name:* )
      */
     public void setProductName_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         this.productNameQuery = SolrQueryBuilder.queryBuilderForExists("product_name");
     }
 
@@ -486,6 +522,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT product_name:* )
      */
     public void setProductName_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         this.productNameQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_name"), false);
     }
 
@@ -498,12 +535,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductName_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productNameQuery = SolrQueryBuilder.queryBuilderForEqual("product_name", query.toString());
         }
     }
 
     public void setProductName_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productNameQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_name", query.toString()), false);
         }
@@ -514,6 +553,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductName_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_name", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -521,6 +561,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductName_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_name", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -528,6 +569,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductName_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_name", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -547,6 +589,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductName_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_name", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -554,6 +597,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductName_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_name", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -561,6 +605,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductName_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_name", this.productNameQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_name", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productNameQuery = convertedQuery;
@@ -584,6 +629,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=product_status:* )
      */
     public void setProductStatus_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         this.productStatusQuery = SolrQueryBuilder.queryBuilderForExists("product_status");
     }
 
@@ -591,6 +637,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT product_status:* )
      */
     public void setProductStatus_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         this.productStatusQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_status"), false);
     }
 
@@ -603,12 +650,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatus_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusQuery = SolrQueryBuilder.queryBuilderForEqual("product_status", query.toString());
         }
     }
 
     public void setProductStatus_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_status", query.toString()), false);
         }
@@ -619,6 +668,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatus_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -626,6 +676,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatus_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -633,6 +684,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatus_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_status", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -652,6 +704,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatus_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_status", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -659,6 +712,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatus_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_status", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -666,6 +720,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatus_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_status", this.productStatusQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_status", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusQuery = convertedQuery;
@@ -689,6 +744,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=product_status_code:* )
      */
     public void setProductStatusCode_Exists() {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         this.productStatusCodeQuery = SolrQueryBuilder.queryBuilderForExists("product_status_code");
     }
 
@@ -696,6 +752,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT product_status_code:* )
      */
     public void setProductStatusCode_NotExists() {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         this.productStatusCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("product_status_code"), false);
     }
 
@@ -708,12 +765,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatusCode_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusCodeQuery = SolrQueryBuilder.queryBuilderForEqual("product_status_code", query.toString());
         }
     }
 
     public void setProductStatusCode_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.productStatusCodeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("product_status_code", query.toString()), false);
         }
@@ -724,6 +783,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatusCode_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status_code", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -731,6 +791,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatusCode_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("product_status_code", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -738,6 +799,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatusCode_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("product_status_code", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -757,6 +819,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatusCode_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("product_status_code", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -764,6 +827,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatusCode_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("product_status_code", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -771,6 +835,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setProductStatusCode_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("product_status_code", this.productStatusCodeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("product_status_code", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.productStatusCodeQuery = convertedQuery;
@@ -794,6 +859,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=register_datetime:* )
      */
     public void setRegisterDatetime_Exists() {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         this.registerDatetimeQuery = SolrQueryBuilder.queryBuilderForExists("register_datetime");
     }
 
@@ -801,6 +867,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT register_datetime:* )
      */
     public void setRegisterDatetime_NotExists() {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         this.registerDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("register_datetime"), false);
     }
 
@@ -813,12 +880,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterDatetime_Equal(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         if (query != null) {
             this.registerDatetimeQuery = SolrQueryBuilder.queryBuilderForEqual("register_datetime", query.toString());
         }
     }
 
     public void setRegisterDatetime_NotEqual(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         if (query != null) {
             this.registerDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("register_datetime", query.toString()), false);
         }
@@ -837,6 +906,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterDatetime_RangeSearch(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        SolrQueryBuilder.assertNullQuery("register_datetime", this.registerDatetimeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("register_datetime", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerDatetimeQuery = convertedQuery;
@@ -860,6 +930,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=register_user:* )
      */
     public void setRegisterUser_Exists() {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         this.registerUserQuery = SolrQueryBuilder.queryBuilderForExists("register_user");
     }
 
@@ -867,6 +938,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT register_user:* )
      */
     public void setRegisterUser_NotExists() {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         this.registerUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("register_user"), false);
     }
 
@@ -879,12 +951,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterUser_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.registerUserQuery = SolrQueryBuilder.queryBuilderForEqual("register_user", query.toString());
         }
     }
 
     public void setRegisterUser_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.registerUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("register_user", query.toString()), false);
         }
@@ -895,6 +969,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterUser_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("register_user", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -902,6 +977,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterUser_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("register_user", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -909,6 +985,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterUser_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("register_user", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -928,6 +1005,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterUser_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("register_user", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -935,6 +1013,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterUser_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("register_user", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -942,6 +1021,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegisterUser_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("register_user", this.registerUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("register_user", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.registerUserQuery = convertedQuery;
@@ -965,6 +1045,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=regular_price:* )
      */
     public void setRegularPrice_Exists() {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         this.regularPriceQuery = SolrQueryBuilder.queryBuilderForExists("regular_price");
     }
 
@@ -972,6 +1053,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT regular_price:* )
      */
     public void setRegularPrice_NotExists() {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         this.regularPriceQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("regular_price"), false);
     }
 
@@ -984,12 +1066,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegularPrice_Equal(Long query) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         if (query != null) {
             this.regularPriceQuery = SolrQueryBuilder.queryBuilderForEqual("regular_price", query.toString());
         }
     }
 
     public void setRegularPrice_NotEqual(Long query) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         if (query != null) {
             this.regularPriceQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("regular_price", query.toString()), false);
         }
@@ -1000,6 +1084,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegularPrice_InScope(Collection<Long> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("regular_price", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.regularPriceQuery = convertedQuery;
@@ -1007,6 +1092,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegularPrice_NotInScope(Collection<Long> queryList) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchLongList("regular_price", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.regularPriceQuery = convertedQuery;
@@ -1026,6 +1112,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setRegularPrice_RangeSearch(Long from, Long to) {
+        SolrQueryBuilder.assertNullQuery("regular_price", this.regularPriceQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("regular_price", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.regularPriceQuery = convertedQuery;
@@ -1049,6 +1136,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=update_datetime:* )
      */
     public void setUpdateDatetime_Exists() {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         this.updateDatetimeQuery = SolrQueryBuilder.queryBuilderForExists("update_datetime");
     }
 
@@ -1056,6 +1144,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT update_datetime:* )
      */
     public void setUpdateDatetime_NotExists() {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         this.updateDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("update_datetime"), false);
     }
 
@@ -1068,12 +1157,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateDatetime_Equal(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         if (query != null) {
             this.updateDatetimeQuery = SolrQueryBuilder.queryBuilderForEqual("update_datetime", query.toString());
         }
     }
 
     public void setUpdateDatetime_NotEqual(java.time.LocalDateTime query) {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         if (query != null) {
             this.updateDatetimeQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("update_datetime", query.toString()), false);
         }
@@ -1092,6 +1183,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateDatetime_RangeSearch(java.time.LocalDateTime from, java.time.LocalDateTime to) {
+        SolrQueryBuilder.assertNullQuery("update_datetime", this.updateDatetimeQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("update_datetime", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateDatetimeQuery = convertedQuery;
@@ -1115,6 +1207,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=update_user:* )
      */
     public void setUpdateUser_Exists() {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         this.updateUserQuery = SolrQueryBuilder.queryBuilderForExists("update_user");
     }
 
@@ -1122,6 +1215,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
      * ExistsQuery( q=NOT update_user:* )
      */
     public void setUpdateUser_NotExists() {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         this.updateUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForExists("update_user"), false);
     }
 
@@ -1134,12 +1228,14 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateUser_Equal(String query) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.updateUserQuery = SolrQueryBuilder.queryBuilderForEqual("update_user", query.toString());
         }
     }
 
     public void setUpdateUser_NotEqual(String query) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         if (DfStringUtil.is_NotNull_and_NotEmpty(query)) {
             this.updateUserQuery = SolrQueryBuilder.wrapNotGroupQuery(SolrQueryBuilder.queryBuilderForEqual("update_user", query.toString()), false);
         }
@@ -1150,6 +1246,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateUser_InScope(Collection<String> queryList, SolrQueryLogicalOperator operator) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("update_user", queryList, operator);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1157,6 +1254,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateUser_NotInScope(Collection<String> queryList) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSearchWordList("update_user", queryList, SolrQueryLogicalOperator.NOT);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1164,6 +1262,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateUser_PrefixSearch(String query) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForPrefixSearch("update_user", query);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1183,6 +1282,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateUser_RangeSearch(String from, String to) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForRangeSearch("update_user", from, to);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1190,6 +1290,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateUser_SetRangeSearch(String cd, String from, String to) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearch("update_user", cd, from, to, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;
@@ -1197,6 +1298,7 @@ public class SolrBsExampleCQ extends AbstractSolrQueryBean {
     }
 
     public void setUpdateUser_SetRangeSearchInScope(Collection<SolrSetRangeSearchBean> beanList) {
+        SolrQueryBuilder.assertNullQuery("update_user", this.updateUserQuery);
         String convertedQuery = SolrQueryBuilder.queryBuilderForSetRangeSearchInScope("update_user", beanList, SET_RANGE_SEARCH_PADDING_LENGTH, PADDING_STR);
         if (DfStringUtil.is_NotNull_and_NotEmpty(convertedQuery)) {
             this.updateUserQuery = convertedQuery;

--- a/src/test/java/org/docksidestage/app/web/solr/SolrExampleTest.java
+++ b/src/test/java/org/docksidestage/app/web/solr/SolrExampleTest.java
@@ -55,15 +55,12 @@ public class SolrExampleTest extends UnitNonrdbTestCase {
         // ## Act ##
         SolrFacetResultBean result = solrExampleBhv.selectFacetQuery(cb -> {
             cb.query().setProductName_Equal("foo");
-            cb.addFacetQuery(qb -> {
-                qb.setLatestPurchaseDate_RangeSearchTo(toLocalDateTime("2015/12/31"));
-                qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/1/1"), toLocalDateTime("2016/3/31"));
-                qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/4/1"), toLocalDateTime("2016/6/30"));
-                qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/7/1"), toLocalDateTime("2016/9/30"));
-                qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/10/1"), toLocalDateTime("2016/12/31"));
-                qb.setLatestPurchaseDate_RangeSearchFrom(toLocalDateTime("2017/1/1"));
-            });
-            cb.query().addOrderBy_ProductName_Asc();
+            cb.addFacetQuery(qb -> qb.setLatestPurchaseDate_RangeSearchTo(toLocalDateTime("2015/12/31")));
+            cb.addFacetQuery(qb -> qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/1/1"), toLocalDateTime("2016/3/31")));
+            cb.addFacetQuery(qb -> qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/4/1"), toLocalDateTime("2016/6/30")));
+            cb.addFacetQuery(qb -> qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/7/1"), toLocalDateTime("2016/9/30")));
+            cb.addFacetQuery(qb -> qb.setLatestPurchaseDate_RangeSearch(toLocalDateTime("2016/10/1"), toLocalDateTime("2016/12/31")));
+            cb.addFacetQuery(qb -> qb.setLatestPurchaseDate_RangeSearchFrom(toLocalDateTime("2017/1/1")));
         });
 
         // ## Assert ##


### PR DESCRIPTION
- Add an assertion expecting the target field should be null
- Assert the target field before registering at set* methods of CQ & CFQ
- Fix test